### PR TITLE
update to 2.11.0-M6

### DIFF
--- a/javaOut/src/test/scala/scala/javadoc/SignatureSpec.scala
+++ b/javaOut/src/test/scala/scala/javadoc/SignatureSpec.scala
@@ -10,7 +10,7 @@ class SignatureSpec extends WordSpec with MustMatchers {
   "The generated java files" must {
 
     "contain the same methods and classes as the original Scala files" in {
-      val scalaCL = new URLClassLoader(Array(new File("tests/target/scala-2.11.0-M5/test-classes/").toURI.toURL), classOf[List[_]].getClassLoader)
+      val scalaCL = new URLClassLoader(Array(new File("tests/target/scala-2.11.0-M6/test-classes/").toURI.toURL), classOf[List[_]].getClassLoader)
 
       val accProtLvl = Map(1 -> 1, 2 -> 3, 4 -> 2)
 

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -18,18 +18,18 @@ class GenJavaDocPlugin(val global: Global) extends Plugin {
   val components = List[PluginComponent](MyComponent)
 
   override def processOptions(options: List[String], error: String ⇒ Unit): Unit = {
-    this.options = new Properties()
+    this.opts = new Properties()
     options foreach { str ⇒
       str.indexOf('=') match {
-        case -1 ⇒ this.options.setProperty(str, "true")
-        case n  ⇒ this.options.setProperty(str.substring(0, n), str.substring(n + 1))
+        case -1 ⇒ opts.setProperty(str, "true")
+        case n  ⇒ opts.setProperty(str.substring(0, n), str.substring(n + 1))
       }
     }
   }
-  var options: Properties = _
+  var opts: Properties = _
 
-  lazy val outputBase = new File(options.getProperty("out", "."))
-  lazy val suppressSynthetic = java.lang.Boolean.parseBoolean(options.getProperty("suppressSynthetic", "true"))
+  lazy val outputBase = new File(opts.getProperty("out", "."))
+  lazy val suppressSynthetic = java.lang.Boolean.parseBoolean(opts.getProperty("suppressSynthetic", "true"))
 
   private object MyComponent extends PluginComponent with Transform {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object B extends Build {
   override lazy val settings = super.settings ++ Seq(
     organization := "com.typesafe.genjavadoc",
     version := "0.6-SNAPSHOT",
-    scalaVersion := "2.11.0-M5")
+    scalaVersion := "2.11.0-M6")
 
   lazy val top = Project(
     id = "top",


### PR DESCRIPTION
@cunei The change needed to make the tests green is a simple one, but it is quite ugly (because it has to be done for every Scala version change): is there a way to pass the output directory for test classes of the `tests` subproject into the test procedure of the `javaOut` project? Or maybe we can override the location of `test-classes` to be stable?