### PR TITLE
Convert Scala @throws annotations to Java throws clauses

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -90,8 +90,12 @@ trait AST { this: TransformCake ⇒
         case Nil                   ⇒ acc
       }
       val args = rec(d.vparamss.head) mkString ("(", ", ", ")")
+
+      val throwsAnnotations = d.symbol.throwsAnnotations.map(_.fullName)
+      val throws = if (throwsAnnotations.isEmpty) "" else "throws " + throwsAnnotations.mkString(", ")
+
       val impl = if (d.mods.isDeferred || interface) ";" else "{ throw new RuntimeException(); }"
-      val pattern = (n: String) ⇒ s"$acc $tp $n $args $impl"
+      val pattern = (n: String) ⇒ s"$acc $tp $n $args $throws $impl"
       def hasParam(n: String) = comment.find(_.contains(s"@param $n")).isDefined
       val commentWithParams =
         if (fabricateParams && comment.size > 1 && comment.head.startsWith("/**")) {

--- a/tests/expected_output/akka/rk/buh/is/it/A.java
+++ b/tests/expected_output/akka/rk/buh/is/it/A.java
@@ -197,6 +197,11 @@ public  class A {
    */
   public  int hello (scala.collection.Seq<java.lang.String> s) { throw new RuntimeException(); }
   /**
+   * throws
+   * @return (undocumented)
+   */
+  public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
+  /**
    * Accessor for nested Scala object
    * @return (undocumented)
    */

--- a/tests/src/test/scala/scala/javadoc/test.scala
+++ b/tests/src/test/scala/scala/javadoc/test.scala
@@ -121,6 +121,13 @@ class A {
   def hello(s: String*) = 0
 
   /**
+   * throws
+   */
+  @throws[IllegalArgumentException]
+  @throws(classOf[NullPointerException])
+  def testthrows = 0
+
+  /**
    * class A.B
    */
   // one line comment


### PR DESCRIPTION
With recent versions of javadoc, checks are made to ensure that throws
clasues exist for any javadoc @throws tags. This patch converts Scala
@throws annotations to the Java throws clause so that these checks can
pass.