### PR TITLE
Wip/reworked pr 58

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ sudo: false
 language: scala
 jdk:
   - openjdk6
+  - oraclejdk8
 # Increasing ReservedCodeCacheSize minimizes scala compiler-interface compile times
 script: sbt -J-XX:ReservedCodeCacheSize=128m +test

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -143,10 +143,10 @@ trait Output { this: TransformCake ⇒
   private def inheritedMethods(sym: global.Symbol, exclude: Set[String]): Seq[MethodInfo] = {
     import global._
     sym.ancestors.reverse
-      .filter(s => s.name != typeNames.Object && s.name != typeNames.Any)
+      .filter(s => s.name != tpnme.Object && s.name != tpnme.Any)
       .flatMap(_.info.nonPrivateDecls)
       .collect { case m: MethodSymbol if !m.isConstructor && !exclude.contains(m.name.toString) => m }
-      .foldLeft(Vector.empty[Symbol])((s, m) => s.filterNot(m.overrides.contains) :+ m)
+      .foldLeft(Vector.empty[Symbol])((s, m) => s.filterNot(m.allOverriddenSymbols.contains) :+ m)
       .map(MethodInfo(_))
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,7 @@ object B extends Build {
     version := "1.0",
     scalaVersion := crossScalaVersions.value.last,
     crossScalaVersions := {
-      val scala210and211Versions = (2 to 5).map(i => s"2.10.$i") ++ (0 to 7).map(i => s"2.11.$i")
+      val scala210and211Versions = (2 to 6).map(i => s"2.10.$i") ++ (0 to 7).map(i => s"2.11.$i")
       ifJavaVersion(_ < 8) {
         scala210and211Versions
       } {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")

--- a/tests/src/test/scala/scala/javadoc/TheSpec.scala
+++ b/tests/src/test/scala/scala/javadoc/TheSpec.scala
@@ -11,7 +11,10 @@ class TheSpec extends WordSpec with Matchers {
   "GenJavaDoc" must {
 
     "generate the expected output" in {
-      lines(run("tests", "diff", "-wurNI", "^ *//", "expected_output/akka", "target/java/akka")) foreach println
+      lines(run("tests", "diff", "-wurN",
+        "-I", "^ *//", // comment lines
+        "-I", "^ *private  java\\.lang\\.Object readResolve", // since Scala 2.12.0-M3, these methods are emitted in a later compiler phase
+         "expected_output/akka", "target/java/akka")) foreach println
     }
 
   }


### PR DESCRIPTION
This PR subsumes #58 and, on top of it, it adds support for Scala 2.10.6.

@2m You can cherry-pick ef54bc6b21e5d032c02f3f769c47dbce2fd751e2 to tag 0.9 and release it for 2.10.6. Thanks!