### PR TITLE
Add support for Scala 2.12.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   - SCALA_VERSION=2.12.0-M1
   - SCALA_VERSION=2.12.0-M2
   - SCALA_VERSION=2.12.0-M3
+  - SCALA_VERSION=2.12.0-M4
 
 matrix:
   exclude:
@@ -41,6 +42,8 @@ matrix:
       env: SCALA_VERSION=2.12.0-M2
     - jdk: openjdk6
       env: SCALA_VERSION=2.12.0-M3
+    - jdk: openjdk6
+      env: SCALA_VERSION=2.12.0-M4
 
 # Increasing ReservedCodeCacheSize minimizes scala compiler-interface compile times
 script:

--- a/javaOut/src/test/scala/scala/javadoc/SignatureSpec.scala
+++ b/javaOut/src/test/scala/scala/javadoc/SignatureSpec.scala
@@ -92,8 +92,10 @@ class SignatureSpec extends WordSpec with Matchers {
         import language.postfixOps
         c.getDeclaredMethods.filterNot(x ⇒ filter && (defaultFilteredStrings.exists { s => x.getName.contains(s) }
           || javaKeywords.contains(x.getName)
+          || x.getName == "$init$" // These synthetic methods show up in 2.12.0-M4+ even though they are not in the generated Java sources
           || startsWithNumber.findFirstIn(x.getName).isDefined))
           .map(_.toGenericString)
+          .map(_.replace("default ", "abstract ")) // Scala 2.12.0-M4+ creates default methods for trait method implementations. We treat them as abstract for now.
           .map(_.replaceAll(exception, replacemnt))
           .toSet
       }

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -107,7 +107,12 @@ trait AST { this: TransformCake ⇒
       }
       val args = rec(d.vparamss.head) mkString ("(", ", ", ")")
 
-      val throwsAnnotations = d.symbol.throwsAnnotations.map(_.fullName)
+      val throwsAnnotations = d.symbol.annotations.collect {
+        case ThrownException(exc) => (exc: Any) match {
+          case s: Symbol => s.fullName
+          case t: Type => t.typeSymbol.fullName // 2.12.0-M4+ has a Type instead of a TypeSymbol in ThrownException
+        }
+      }
       val throws = if (throwsAnnotations.isEmpty) "" else "throws " + throwsAnnotations.mkString(", ")
 
       val impl = if (d.mods.isDeferred || interface) ";" else "{ throw new RuntimeException(); }"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,7 +24,7 @@ object B extends Build {
       ifJavaVersion(_ < 8) {
         scala210and211Versions
       } {
-        scala210and211Versions ++ (1 to 3).map(i => s"2.12.0-M$i")
+        scala210and211Versions ++ (1 to 4).map(i => s"2.12.0-M$i")
       }
     },
     scalaTestVersion := {
@@ -32,6 +32,7 @@ object B extends Build {
         case "2.12.0-M1" => "2.2.5-M1"
         case "2.12.0-M2" => "2.2.5-M2"
         case "2.12.0-M3" => "2.2.5-M3"
+        case "2.12.0-M4" => "2.2.6"
         case _ => "2.1.3"
       }
     },


### PR DESCRIPTION
For now this is on the same level as for the other supported Scala
versions. Default methods (which can be produced by M4) are still
translated like abstract interface methods.