### PR TITLE
Mangle static forwarders

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -132,11 +132,11 @@ trait Output { this: TransformCake ⇒
     val nestedStaticClasses = flatten(staticClasses, forwarders = false, staticScope = staticScope)
     if (forwarders) {
       val base = cls.copy(members = nestedClasses ++ nestedStaticClasses ++ staticMethods ++ methods)
-      Vector(base, mangleModule(obj, addMODULE = forwarders, pruneClasses = true))
+      flatten(Vector(base)) ++ Vector(mangleModule(obj, addMODULE = forwarders, pruneClasses = true))
     } else {
       val base = cls.copy(members = nestedClasses ++ staticMethods ++ methods)
       val mod = mangleModule(obj, addMODULE = forwarders, pruneClasses = true)
-      Vector(base, mod.copy(members = nestedStaticClasses ++ mod.members))
+      flatten(Vector(base)) ++ Vector(mod.copy(members = nestedStaticClasses ++ mod.members))
     }
   }
 

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/Reserved.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/Reserved.java
@@ -1,0 +1,4 @@
+package akka.rk.buh.is.it;
+public abstract class Reserved {
+    public   Reserved ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ReservedImpl$.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ReservedImpl$.java
@@ -1,0 +1,8 @@
+package akka.rk.buh.is.it;
+public class ReservedImpl$ extends akka.rk.buh.is.it.Reserved {
+    /**
+     * Static reference to the singleton instance of this Scala object.
+     */
+    public static final ReservedImpl$ MODULE$ = null;
+    public ReservedImpl$ () { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ReservedImpl.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ReservedImpl.java
@@ -1,0 +1,3 @@
+package akka.rk.buh.is.it;
+public class ReservedImpl {
+}

--- a/plugin/src/test/resources/input/basic/test.scala
+++ b/plugin/src/test/resources/input/basic/test.scala
@@ -369,3 +369,10 @@ object EWMA {
     1 - math.exp(-decayRate * collectInterval.toMillis)
   }
 }
+
+abstract class Reserved {
+  //reserved keyword in java, should not be generated
+  final def goto(x: String): String = x
+}
+
+object ReservedImpl extends Reserved


### PR DESCRIPTION
Currently inherited methods and static forwarders are not filtered for java keywords, causing errors in javadoc. This PR removes such reserved-word methods.

Fixes #81.

Tested on latest Akka master.