### PR TITLE
+add some more maintainer info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,8 @@ This software is licensed under the Apache 2 license.
 
 ### Sponsored by Lightbend
 
-Responsible: Dr. Roland Kuhn
+Responsible: Dr. Roland Kuhn (@rkuhn)
+Maintained mostly by @akka team (@2m, @ktoso)
+
+Feel free to ping above maintainers for code review or discussions. 
+Pull requests are very welcome–thanks in advance!


### PR DESCRIPTION
During the last eng meeting we thought that repos under typesafehub and lightbend should have an explicit "who to ping" / "maintainer" written up in the readme.

Status quo is that we mostly maintain it, so WDYT about such note below?