### PR TITLE
Provide compatibility with Scala 2.12.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,25 +28,13 @@ env:
   - SCALA_VERSION=2.11.6
   - SCALA_VERSION=2.11.7
   - SCALA_VERSION=2.11.8
-  - SCALA_VERSION=2.12.0-M1
-  - SCALA_VERSION=2.12.0-M2
-  - SCALA_VERSION=2.12.0-M3
-  - SCALA_VERSION=2.12.0-M4
-  - SCALA_VERSION=2.12.0-M5
+  - SCALA_VERSION=2.12.0-RC1
 
 matrix:
   exclude:
     # scala 2.12.x requires jdk8
     - jdk: openjdk6
-      env: SCALA_VERSION=2.12.0-M1
-    - jdk: openjdk6
-      env: SCALA_VERSION=2.12.0-M2
-    - jdk: openjdk6
-      env: SCALA_VERSION=2.12.0-M3
-    - jdk: openjdk6
-      env: SCALA_VERSION=2.12.0-M4
-    - jdk: openjdk6
-      env: SCALA_VERSION=2.12.0-M5
+      env: SCALA_VERSION=2.12.0-RC1
 
 # Increasing ReservedCodeCacheSize minimizes scala compiler-interface compile times
 script:

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
@@ -91,13 +91,19 @@ trait BasicTransform { this: TransformCake ⇒
           superTransform(tree)
         }
       case d: DefDef if keep ⇒
-        val (lookat, end) =
-          if (d.name == nme.CONSTRUCTOR) {
-            if (clazz.get.constructor) (d.symbol.enclClass.pos, None)
-            else (d.pos, endPos(d.rhs))
-          } else (d.pos, endPos(d.rhs))
-        // must be called for keeping the “current” position right
-        val text = commentText(lookat, end)
+        val text =
+          if (d.mods.hasModuleFlag) { // accessor for an object
+            // the accessor occurs out of order; we must not advance the position
+            Nil
+          } else {
+            val (lookat, end) =
+              if (d.name == nme.CONSTRUCTOR) {
+                if (clazz.get.constructor) (d.symbol.enclClass.pos, None)
+                else (d.pos, endPos(d.rhs))
+              } else (d.pos, endPos(d.rhs))
+            // must be called for keeping the “current” position right
+            commentText(lookat, end)
+          }
         val name = d.name.toString
         if (!skippedName(name)) {
           if (d.mods.hasFlag(Flags.VARARGS)) addVarargsMethod(d, text)

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -59,7 +59,11 @@ class GenJavaDocPlugin(val global: Global) extends Plugin {
 
     override val global: GT = GenJavaDocPlugin.this.global
 
-    override val runsAfter = List("uncurry")
+    val isPreFields = {
+      val v = nsc.Properties.versionNumberString
+      Set("2.12.0-M1", "2.12.0-M2", "2.12.0-M3", "2.12.0-M4", "2.12.0-M5").contains(v) || v.startsWith("2.10.") || v.startsWith("2.11.")
+    }
+    override val runsAfter = List(if(isPreFields) "uncurry" else "fields")
     val phaseName = "GenJavaDoc"
 
     def newTransformer(unit: CompilationUnit) = new GenJavaDocTransformer(unit)

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
@@ -55,7 +55,6 @@ public  class A {
      */
     public  long math ()  { throw new RuntimeException(); }
     public  akka.rk.buh.is.it.A.D$.E$ E ()  { throw new RuntimeException(); }
-    private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
   }
   /**
    * class A.B

--- a/plugin/src/test/resources/patches/2.12.0-RC1.patch
+++ b/plugin/src/test/resources/patches/2.12.0-RC1.patch
@@ -1,0 +1,53 @@
+--- target/expected_output/basic/akka/rk/buh/is/it/A.java
++++ target/expected_output/basic/akka/rk/buh/is/it/A.java
+@@ -48,13 +48,13 @@
+     public  class NonStatic {
+       public   NonStatic ()  { throw new RuntimeException(); }
+     }
++    public  akka.rk.buh.is.it.A.D$.E$ E ()  { throw new RuntimeException(); }
+     public   D$ ()  { throw new RuntimeException(); }
+     /**
+      * def A.D.math
+      * @return (undocumented)
+      */
+     public  long math ()  { throw new RuntimeException(); }
+-    public  akka.rk.buh.is.it.A.D$.E$ E ()  { throw new RuntimeException(); }
+   }
+   /**
+    * class A.B
+@@ -94,12 +94,12 @@
+     public  class C1$ {
+       public   C1$ ()  { throw new RuntimeException(); }
+     }
+-    public   C1 ()  { throw new RuntimeException(); }
+     /**
+      * Accessor for nested Scala object
+      * @return (undocumented)
+      */
+     public  akka.rk.buh.is.it.A.C1.C1$ C1 ()  { throw new RuntimeException(); }
++    public   C1 ()  { throw new RuntimeException(); }
+   }
+   /**
+    * object C1
+@@ -147,6 +147,11 @@
+   static public  java.lang.String stattic ()  { throw new RuntimeException(); }
+   static public  java.lang.Object x ()  { throw new RuntimeException(); }
+   /**
++   * Accessor for nested Scala object
++   * @return (undocumented)
++   */
++  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
++  /**
+    * varargs
+    * @param s (undocumented)
+    * @return (undocumented)
+@@ -219,9 +224,4 @@
+    */
+   public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
+   public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
+-  /**
+-   * Accessor for nested Scala object
+-   * @return (undocumented)
+-   */
+-  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
+ }

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.WordSpec
 
 import util._
 
+import scala.sys.process._
+
 object BasicSpec {
   def sources: Seq[String] = Seq(
     "src/test/resources/input/basic/test.scala",
@@ -17,6 +19,17 @@ object BasicSpec {
 class BasicSpec extends WordSpec with Matchers with CompilerSpec {
 
   override def sources = BasicSpec.sources
-  override def expectedPath: String = "src/test/resources/expected_output/basic"
+  override def expectedPath: String = {
+
+    val patchFile = s"src/test/resources/patches/${scala.util.Properties.versionNumberString}.patch"
+    if (new java.io.File(patchFile).exists) { // we have a patch to apply to expected output for this scala version
+      "rm -rf target/expected_output".! // cleanup from previous runs
+      "cp -r src/test/resources/expected_output target/".! // copy expected output to a place which is going to be patched
+      s"patch -p0 -i $patchFile".! // path expected output
+      "target/expected_output/basic"
+    } else {
+      "src/test/resources/expected_output/basic"
+    }
+  }
 
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,16 +27,12 @@ object B extends Build {
       ifJavaVersion(_ < 8) {
         scala210and211Versions
       } {
-        scala210and211Versions ++ (1 to 5).map(i => s"2.12.0-M$i")
+        scala210and211Versions ++ (1 to 1).map(i => s"2.12.0-RC$i")
       }
     },
     scalaTestVersion := {
       scalaVersion.value match {
-        case "2.12.0-M1" => "2.2.5-M1"
-        case "2.12.0-M2" => "2.2.5-M2"
-        case "2.12.0-M3" => "2.2.5-M3"
-        case "2.12.0-M4" => "2.2.6"
-        case "2.12.0-M5" => "3.0.0-RC4"
+        case "2.12.0-RC1" => "3.0.0"
         case _ => "2.1.3"
       }
     },


### PR DESCRIPTION
- The plugin now has to run after `fields` instead of `uncurry`.

- The ordering of synthetic accessors is different. Module accessors
  appear at the beginning the surrounding scope and have the same
  position as the module, so we do not advance the position anymore
  for them.

One test still fails because of other differences in ordering. The
result looks correct and will likely need a different expected outcome
for post-fields-refactoring Scala versions.