### PR TITLE
Adapt to 2.12.1

### DIFF
--- a/plugin/src/main/scala-2.10/com/typesafe/genjavadoc/Comments.scala
+++ b/plugin/src/main/scala-2.10/com/typesafe/genjavadoc/Comments.scala
@@ -1,6 +1,13 @@
 package com.typesafe.genjavadoc
 
+import scala.tools.nsc.ast.parser.SyntaxAnalyzer
+
 trait Comments extends BaseComments { this: TransformCake =>
+  object parser extends {
+    val global: Comments.this.global.type = Comments.this.global
+    val runsAfter = List[String]()
+    val runsRightAfter = None
+  } with SyntaxAnalyzer
 
   override def parseComments(): Unit =
     new parser.UnitParser(unit) {

--- a/plugin/src/main/scala-2.11/com/typesafe/genjavadoc/Comments.scala
+++ b/plugin/src/main/scala-2.11/com/typesafe/genjavadoc/Comments.scala
@@ -1,8 +1,14 @@
 package com.typesafe.genjavadoc
 
 import scala.reflect.internal.util.RangePosition
+import scala.tools.nsc.ast.parser.SyntaxAnalyzer
 
 trait Comments extends BaseComments { this: TransformCake =>
+  object parser extends {
+    val global: Comments.this.global.type = Comments.this.global
+    val runsAfter = List[String]()
+    val runsRightAfter = None
+  } with SyntaxAnalyzer
 
   override def parseComments(): Unit =
     new parser.UnitParser(unit) {

--- a/plugin/src/main/scala-2.12/com/typesafe/genjavadoc/Comments.scala
+++ b/plugin/src/main/scala-2.12/com/typesafe/genjavadoc/Comments.scala
@@ -1,44 +1,19 @@
 package com.typesafe.genjavadoc
-
-import scala.reflect.internal.util.RangePosition
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.doc.ScaladocSyntaxAnalyzer
 
 trait Comments extends BaseComments { this: TransformCake =>
+  object parser extends {
+    val runsAfter = List[String]()
+    val runsRightAfter = None
+  } with ScaladocSyntaxAnalyzer[global.type](global)
 
   override def parseComments(): Unit =
-    new parser.UnitParser(unit) {
-      override def newScanner = new parser.UnitScanner(unit) {
-        // This is for 2.11
-        private var docBuffer: StringBuilder = null // buffer for comments (non-null while scanning)
-        private var inDocComment = false // if buffer contains double-star doc comment
-
-        override protected def putCommentChar() {
-          if (inDocComment)
-            docBuffer append ch
-
-          nextChar()
-        }
-        override def skipDocComment(): Unit = {
-          inDocComment = true
-          docBuffer = new StringBuilder("/**")
-          super.skipDocComment()
-        }
-        override def skipBlockComment(): Unit = {
-          inDocComment = false
-          docBuffer = new StringBuilder("/*")
-          super.skipBlockComment()
-        }
-        override def skipComment(): Boolean = {
-          // emit a block comment; if it's double-star, make Doc at this pos
-          def foundStarComment(start: Int, end: Int) = try {
-            val str = docBuffer.toString
-            val pos = new RangePosition(unit.source, start, start, end)
-            comments += pos -> Comment(pos, str)
-            true
-          } finally {
-            docBuffer = null
-            inDocComment = false
-          }
-          super.skipComment() && ((docBuffer eq null) || foundStarComment(offset, charOffset - 2))
+    new parser.ScaladocUnitParser(unit, Nil) {
+      override def newScanner = new parser.ScaladocUnitScanner(unit, Nil) {
+        override def registerDocComment(str: String, pos: Position) = {
+          super.registerDocComment(str, pos)
+          comments += pos -> Comment(pos, str)
         }
       }
     }.parse()

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/BaseComments.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/BaseComments.scala
@@ -1,19 +1,12 @@
 package com.typesafe.genjavadoc
 
 import scala.collection.immutable.TreeMap
-import scala.tools.nsc.ast.parser.SyntaxAnalyzer
 import scala.annotation.tailrec
 
 trait BaseComments { this: TransformCake ⇒
   import global._
 
   def unit: CompilationUnit
-
-  object parser extends {
-    val global: BaseComments.this.global.type = BaseComments.this.global
-    val runsAfter = List[String]()
-    val runsRightAfter = None
-  } with SyntaxAnalyzer
 
   private val replacements = Seq(
     "{{{" -> "<pre><code>",


### PR DESCRIPTION
Use 2.11 interface for 2.12.0, as it's identical.

From 2.12.1 on, there's a hook method that can be
used instead of copy/paste polymorphism.

One test failure due to a change in how members are sorted.

PS: since sbt 0.13.8, there's no need to manually add
versioned source files. Sadly, we need a special case for 2.12.0