### PR TITLE
fix a pathname handling bug in the build

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -76,7 +76,7 @@ object B extends Build {
         val default = (unmanagedSourceDirectories in Compile).value
         def r(from: String, to: String) = default.map(f => new java.io.File(f.getPath.replaceAll(from, to)))
         if (scalaVersion.value == "2.12.0") r("""/scala-2\.12$""", "/scala-2.11")
-        else if (scalaVersion.value.startsWith("2.13.")) r("""/scala-2\.13.*$""", "/scala-2.12")
+        else if (scalaVersion.value.startsWith("2.13.")) r("""/scala-2\.13[^/]*$""", "/scala-2.12")
         else default
       },
       crossVersion := CrossVersion.full,


### PR DESCRIPTION
this was failing when "scala-2.13" appeared at the start of the name
of an enclosing directory, e.g. if an enclosing directory happened to
be called "scala-2.13.x-community-build", but surely that would never
happen, right?